### PR TITLE
Removed locale from Mozilla link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Firefox
 Looking for the Chrome version? See: https://github.com/erkserkserks/h264ify
 
 # Installation
-Install from here: https://addons.mozilla.org/en-US/firefox/addon/h264ify/
+Install from here: https://addons.mozilla.org/firefox/addon/h264ify/
 
 If all goes well, when you visit https://www.youtube.com/html5, you should see this:
 ![](https://raw.githubusercontent.com/erkserkserks/h264ify-firefox/master/noncode/screenshot_support.png)


### PR DESCRIPTION
Removed locale string from the Mozilla link, so that it loads in the user's default browser language.
